### PR TITLE
Timeout on a hung TCP connection

### DIFF
--- a/include/ur_modern_driver/ros/action_server.h
+++ b/include/ur_modern_driver/ros/action_server.h
@@ -43,6 +43,7 @@ private:
 
   RobotState state_;
   bool use_smooth_trajectory_;
+  bool kill_on_hang_;
   std::array<double, 6> q_actual_, qd_actual_;
 
   void onGoal(GoalHandle gh);

--- a/include/ur_modern_driver/ros/action_server.h
+++ b/include/ur_modern_driver/ros/action_server.h
@@ -42,6 +42,7 @@ private:
   TrajectoryFollower& follower_;
 
   RobotState state_;
+  bool use_smooth_trajectory_;
   std::array<double, 6> q_actual_, qd_actual_;
 
   void onGoal(GoalHandle gh);
@@ -59,6 +60,9 @@ private:
 
   void trajectoryThread();
   bool updateState(RTShared& data);
+
+  bool reachedGoal(const TrajectoryPoint& goal_point);
+  bool inMotion();
 
 public:
   ActionServer(TrajectoryFollower& follower, std::vector<std::string>& joint_names, double max_velocity);

--- a/include/ur_modern_driver/ros/trajectory_follower.h
+++ b/include/ur_modern_driver/ros/trajectory_follower.h
@@ -39,6 +39,7 @@ private:
   int reverse_port_;
 
   double servoj_time_, servoj_lookahead_time_, servoj_gain_;
+  double max_acceleration_;
   std::string program_;
 
   template <typename T>
@@ -51,6 +52,9 @@ private:
 
   bool execute(std::array<double, 6> &positions, bool keep_alive);
   double interpolate(double t, double T, double p0_pos, double p1_pos, double p0_vel, double p1_vel);
+  bool computeVelocityAndAccel(double dphi, double dt,
+			       double max_vel, double max_accel,
+			       double& vel, double& accel);
 
 public:
   TrajectoryFollower(URCommander &commander, std::string &reverse_ip, int reverse_port, bool version_3);

--- a/include/ur_modern_driver/ros/trajectory_follower.h
+++ b/include/ur_modern_driver/ros/trajectory_follower.h
@@ -7,6 +7,7 @@
 #include <cstring>
 #include <string>
 #include <thread>
+#include <mutex>
 #include <vector>
 #include "ur_modern_driver/log.h"
 #include "ur_modern_driver/ur/commander.h"
@@ -42,6 +43,10 @@ private:
   double max_acceleration_;
   std::string program_;
 
+  std::mutex mutex_;
+  std::thread server_thread_;
+  bool timeout_canceled_;
+
   template <typename T>
   size_t append(uint8_t *buffer, T &val)
   {
@@ -50,6 +55,7 @@ private:
     return s;
   }
 
+  void serverThread();
   bool execute(std::array<double, 6> &positions, bool keep_alive);
   double interpolate(double t, double T, double p0_pos, double p1_pos, double p0_vel, double p1_vel);
   bool computeVelocityAndAccel(double dphi, double dt,
@@ -60,8 +66,8 @@ public:
   TrajectoryFollower(URCommander &commander, std::string &reverse_ip, int reverse_port, bool version_3);
 
   bool start();
-  bool startSmoothTrajectory(const std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt);
-    bool startTimedTrajectory(const std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt);
+  bool startSmoothTrajectory(const std::vector<TrajectoryPoint> &trajectory);
+  bool startTimedTrajectory(const std::vector<TrajectoryPoint> &trajectory);
   bool execute(std::array<double, 6> &positions);
   bool execute(std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt);
   void stop();

--- a/include/ur_modern_driver/ros/trajectory_follower.h
+++ b/include/ur_modern_driver/ros/trajectory_follower.h
@@ -60,7 +60,8 @@ public:
   TrajectoryFollower(URCommander &commander, std::string &reverse_ip, int reverse_port, bool version_3);
 
   bool start();
-  bool start(const std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt);
+  bool startSmoothTrajectory(const std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt);
+    bool startTimedTrajectory(const std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt);
   bool execute(std::array<double, 6> &positions);
   bool execute(std::vector<TrajectoryPoint> &trajectory, std::atomic<bool> &interrupt);
   void stop();

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -16,6 +16,7 @@
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
   <arg name="shutdown_on_disconnect" default="true" />
+  <arg name="use_smooth_trajectory" default="true"/>
 
   <!-- require_activation defines when the service /ur_driver/robot_enable needs to be called. -->
   <arg name="require_activation" default="Never" /> <!-- Never, Always, OnStartup -->
@@ -38,5 +39,6 @@
     <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
     <param name="require_activation" type="str" value="$(arg require_activation)" />
     <param name="shutdown_on_disconnect" type="bool" value="$(arg shutdown_on_disconnect)"/>
+    <param name="use_smooth_trajectory" type="bool" value="$(arg use_smooth_trajectory)"/>
   </node>
 </launch>

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -27,7 +27,7 @@
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
   <!-- driver -->
-  <node name="ur_driver" pkg="ur_modern_driver" type="ur_driver" output="screen">
+  <node name="ur_driver" pkg="ur_modern_driver" type="ur_driver" output="screen" respawn="true">
   <!-- copy the specified IP address to be consistant with ROS-Industrial spec. -->
     <param name="prefix" type="str" value="$(arg prefix)" />
     <param name="robot_ip_address" type="str" value="$(arg robot_ip)" />

--- a/src/ros/action_server.cpp
+++ b/src/ros/action_server.cpp
@@ -334,16 +334,15 @@ void ActionServer::trajectoryThread()
     {
       if (!follower_.startSmoothTrajectory(trajectory))
       {
-	LOG_ERROR("Robot has hung.");
+	LOG_WARN("Robot has hung.");
 	res.error_code = -100;
 	res.error_string = "Robot has hung. ";
 	curr_gh_.setAborted(res, res.error_string);	
 
         if (kill_on_hang_)
         {
-          LOG_ERROR("Preparing to kill the robot driver. Consider configuring "
-		    "the driver to respawn using the the appropriate "
-		    "launch-prefix.");
+          LOG_ERROR("Preparing to kill the robot driver. Note that the driver "
+                    "can recover if it is configured to automatically respawn.");
 
           ros::Duration(0.25).sleep();
           exit(0);
@@ -409,16 +408,15 @@ void ActionServer::trajectoryThread()
       }
       else
       {
-	LOG_ERROR("Robot has hung.");
-	res.error_code = -100;
-	res.error_string = "Robot has hung. ";
-	curr_gh_.setAborted(res, res.error_string);	
-
+        LOG_WARN("Robot has hung.");
+        res.error_code = -100;
+        res.error_string = "Robot has hung. ";
+        curr_gh_.setAborted(res, res.error_string);	
+        
         if (kill_on_hang_)
         {
-          LOG_ERROR("Preparing to kill the robot driver. Consider configuring "
-		    "the driver to respawn using the the appropriate "
-		    "launch-prefix.");
+          LOG_ERROR("Preparing to kill the robot driver. Note that the driver "
+                    "can recover if it is configured to automatically respawn.");
 
           ros::Duration(0.25).sleep();
           exit(0);

--- a/src/ros/trajectory_follower.cpp
+++ b/src/ros/trajectory_follower.cpp
@@ -300,8 +300,10 @@ bool TrajectoryFollower::startSmoothTrajectory(const std::vector<TrajectoryPoint
     std::lock_guard<std::mutex> lock(mutex_);
     if (timeout_canceled_)
     {
+      server_thread_.join();
       break;
     }
+    usleep(10);
   }
 
   // The trajectory process is locked
@@ -320,7 +322,6 @@ void TrajectoryFollower::serverThread()
   // the robot pauses for a noticeable amount of time before executing the 
   // trajectory. With this, it executes immediately.
   server_.accept();
-
   // If accept() returns, then we can just return, but first make sure that the
   // timeout has been canceled.
   {

--- a/src/ros/trajectory_follower.cpp
+++ b/src/ros/trajectory_follower.cpp
@@ -415,8 +415,10 @@ bool TrajectoryFollower::startTimedTrajectory(const std::vector<TrajectoryPoint>
     std::lock_guard<std::mutex> lock(mutex_);
     if (timeout_canceled_)
     {
+      server_thread_.join();
       break;
     }
+    usleep(10);
   }
 
   // The trajectory process is locked


### PR DESCRIPTION
It was discovered that the TCP server connection gets hung when attempting to execute a trajectory in certain circumstances. This branch checks for a hung connection, and if one is encountered it sends an abort response to the action client and kills the node with exit(). Using a respawn="true" tag in a launch file with the driver enables it to recover from a range of conditions (like attempting to command the robot when it is in local control (pendant) mode) that result in a hung connection.

This is not an elegant solution to a hung connection, but it requires mostly only superficial changes to the driver, and it seems to work well. Note that this started from the branch used in this pull request: https://github.com/plusone-robotics/ur_modern_driver/pull/3, so if this pull request is acceptable, then it would be okay to close the former, and just merge this one.
