### PR TITLE
added close after shutdown within TCPSocket::close

### DIFF
--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -91,6 +91,7 @@ void TCPSocket::close()
     return;
   state_ = SocketState::Closed;
   ::shutdown(socket_fd_, SHUT_RDWR);
+  ::close(socket_fd_);
   socket_fd_ = -1;
 }
 


### PR DESCRIPTION
this was tested on the cell and looks like it fixes the issue of continually growing file descriptors.