### PR TITLE
Fixed robot software version check to account for versions higher than 3

### DIFF
--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -91,7 +91,7 @@ public:
 
   bool isVersion3()
   {
-    return major_version_ == 3;
+    return major_version_ >= 3;
   }
 
   std::unique_ptr<URCommander> getCommander(URStream& stream)


### PR DESCRIPTION
e-series robots are currently shipped with version 5 of the polyscope software, so this check fails when trying to use the low-bandwidth trajectory follower (and presumably other functions I haven't yet explored).

Low-bandwidth trajectory follower seems to work as expected on version 5.3.0

In the future, it's probably worth renaming this check and perhaps expanding it since there seems to be significant differences between polyscope versions.